### PR TITLE
Support of flat .json files without splitting composite keys by .

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ The following json structure:
 ```
 Produces a key named `app.name`
 
+Flat json files are also supported (note: use `-fk` argument for excelToJson):
+```json
+{
+  "app.name": "App Name"
+}
+```
+
 ## Installation
 
 Clone the project:
@@ -71,7 +78,9 @@ It produces an excel file named translations.xlsx structured as:
 - `-h` Instructions on the script usage 
 - `-o`/`--output-file` where the excel file must be created (default `output/translations.xlsx`)
 - `-i`/`--input-dir` where the translation files are located (default `translations/`)
-- `-p`/`--primary` where the excel file must be created (default `en`)
+- `-k`/`--key-name` name of the excel column containing the keys (default `key`)
+- `-n`/`--name` a name of the excel sheet (default `Translations`)
+- `-p`/`--primary` a translation file name without .json to be used as the primary language (default `en`)
 - `-l`/`--locales` A comma-separated list of the locales to select (default all json files in the input directory)
 
 
@@ -93,4 +102,5 @@ It produces a json file for each locale containing the corresponding translation
 - `-i`/`--input-file` location of the excel input file (default `output/translations.xlsx`)
 - `-e`/`--empty` set this flag to also include keys without a translation (default is to NOT include keys without a translation, assuming there is a fallback mechanism in your app for such strings)
 - `-k`/`--key-name` name of the excel column containing the keys (default `key`)
-- `-id`/`--indent-size` size of the Json indentation (default is `4`)
+- `-is`/`--indent-size` size of the Json indentation (default is `4`)
+- `-fk`/`--flat-keys` set this flag to keep composite keys in output json files which will make them flat key-values objects (default is to split composite keys by .)

--- a/excelToJson.py
+++ b/excelToJson.py
@@ -1,7 +1,8 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 import json
-import pandas as pd
 from argparse import ArgumentParser
+
+import pandas as pd
 
 parser = ArgumentParser(description='Generate JSON files from the excel.')
 
@@ -9,7 +10,7 @@ parser.add_argument(
     "-k",
     "--key-name",
     dest="key_name",
-    help="Name of the Excel column storing the keys (default: 'key') ",
+    help="Name of the Excel column storing the keys (default: '%(default)s') ",
     default="key"
 )
 
@@ -17,7 +18,7 @@ parser.add_argument(
     "-i",
     "--input-file",
     dest="input_file",
-    help="Name of the input file (default 'output/translations.xlsx')",
+    help="Name of the input file (default '%(default)s')",
     default="output/translations.xlsx"
 )
 
@@ -25,7 +26,7 @@ parser.add_argument(
     "-o",
     "--output-dir",
     dest="output_dir",
-    help="Dir where the output files will be written (default 'output/')",
+    help="Dir where the output files will be written (default '%(default)s')",
     default="output/"
 )
 
@@ -41,8 +42,17 @@ parser.add_argument(
     "-is",
     "--indent-size",
     dest="indent_size",
-    help="Size of the output Json indentation (default 4)",
+    help="Size of the output Json indentation (default %(default)s)",
+    type=int,
     default=4
+)
+
+parser.add_argument(
+    "-fk",
+    "--flat-keys",
+    dest="split_steps",
+    help="Set this flag if you want to keep composite keys in your output Json (default is to split composite keys by .)",
+    action="store_false",
 )
 
 args = parser.parse_args()
@@ -50,6 +60,8 @@ args = parser.parse_args()
 file = args.input_file
 key_field = args.key_name
 output_dir = args.output_dir
+empty_flag = args.empty_flag
+split_steps = args.split_steps
 
 xl = pd.ExcelFile(file)
 df = xl.parse().fillna('')
@@ -66,28 +78,25 @@ for lang in langs:
 
 
 for index, row in df.iterrows():
-    key = row['key']
+    key = row[key_field].strip()
 
-    steps = key.split('.')
+    steps = key.split('.') if split_steps else (key,)
 
     for lang in langs:
         lang_trans = lang_translations[lang]
 
         for idx, step in enumerate(steps):
-            if step not in lang_trans and idx != len(steps)-1:
+            if step not in lang_trans and idx != len(steps) - 1:
                 lang_trans[step] = {}
                 lang_trans = lang_trans[step]
-            elif idx != len(steps)-1:
+            elif idx != len(steps) - 1:
                 lang_trans = lang_trans[step]
 
-        if args.empty_flag or row[lang] != '':
+        if empty_flag or row[lang]:
             if not isinstance(lang_trans, str):
-                lang_trans[steps[-1]] = row[lang].rstrip()
+                lang_trans[steps[-1]] = row[lang].strip()
 
 for lang in langs:
     out_file = open(f"{output_dir}/{lang}.json", 'w')
     json.dump(lang_translations[lang], out_file, indent=args.indent_size, ensure_ascii=False)
     out_file.close()
-
-
-


### PR DESCRIPTION
Hello, I've slightly updated the scripts to support flat json files for translations without splitting composite keys by `.`

For `excelToJson.py` the default mode was kept to create nested dictionaries in output Json, and a new argument `-fk`/`--flat-keys` added for those who need to have a flat key-values structure in Json files.

`jsonToExcel.py` supports both modes without extra arguments (it was changed to check for translations by the full key before splitting it by `.`).

I've also made some smaller changes to get a more Pythonic way of some code lines, and fixed a couple of mistakes in README